### PR TITLE
fix(ci): publish 워크플로우 dist 경로 수정

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Test built package
         working-directory: packages/electron-mcp-server
-        run: bun dist/index.js --help || true
+        run: bun dist/index.cjs --help || true
 
       - name: Publish to npm
         working-directory: packages/electron-mcp-server


### PR DESCRIPTION
## Summary
- `publish.yml`의 테스트 경로 `dist/index.js` → `dist/index.cjs` 수정
- tsdown 빌드 출력이 `.cjs`로 변경된 것에 맞춤

## Test plan
- [x] 릴리즈 생성 시 publish 워크플로우가 정상 실행되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)