### PR TITLE
chore: version bump v0.1.0-rc.6

### DIFF
--- a/packages/electron-mcp-server/package.json
+++ b/packages/electron-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ohah/electron-mcp-server",
-  "version": "0.1.0-rc.5",
+  "version": "0.1.0-rc.6",
   "description": "MCP server for Electron app automation via CDP. Agent-browser style compact refs. Use with any Electron app running --remote-debugging-port=9222.",
   "keywords": [
     "automation",


### PR DESCRIPTION
## Summary

- version bump: `0.1.0-rc.5` → `0.1.0-rc.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)