### PR TITLE
perf: 포트 스캔 병렬화, 결과 캐싱, CDP enable 병렬화

### DIFF
--- a/packages/electron-mcp-server/src/tools/console.ts
+++ b/packages/electron-mcp-server/src/tools/console.ts
@@ -473,10 +473,12 @@ async function startConsoleCaptureIfNeeded(includeMainProcess: boolean): Promise
         clearConsoleState();
       }
     });
-    await sendCdp(rendererWs, 'Console.enable');
-    await sendCdp(rendererWs, 'Page.enable');
-    await sendCdp(rendererWs, 'Log.enable');
-    await sendCdp(rendererWs, 'Runtime.enable');
+    await Promise.all([
+      sendCdp(rendererWs, 'Console.enable'),
+      sendCdp(rendererWs, 'Page.enable'),
+      sendCdp(rendererWs, 'Log.enable'),
+      sendCdp(rendererWs, 'Runtime.enable'),
+    ]);
     logger.debug('Console capture started for renderer', rendererTarget.id);
   } else {
     rendererWs = null;
@@ -493,13 +495,13 @@ async function startConsoleCaptureIfNeeded(includeMainProcess: boolean): Promise
     currentMainWs.on('error', () => {
       if (mainWs === currentMainWs) mainWs = null;
     });
-    await sendCdp(currentMainWs, 'Console.enable');
-    try {
-      await sendCdp(currentMainWs, 'Log.enable');
-    } catch {
-      // Node(메인) 타겟은 Log.enable 미지원일 수 있음
-    }
-    await sendCdp(currentMainWs, 'Runtime.enable');
+    await Promise.all([
+      sendCdp(currentMainWs, 'Console.enable'),
+      sendCdp(currentMainWs, 'Log.enable').catch(() => {
+        // Node(메인) 타겟은 Log.enable 미지원일 수 있음
+      }),
+      sendCdp(currentMainWs, 'Runtime.enable'),
+    ]);
     logger.debug('Console capture started for main process');
   }
 }

--- a/packages/electron-mcp-server/src/tools/electron/discovery.ts
+++ b/packages/electron-mcp-server/src/tools/electron/discovery.ts
@@ -18,41 +18,67 @@ const logger = createLogger('discovery');
 /** 스캔 실패 시 마지막 원인(디버깅용). */
 let lastScanError: string | undefined;
 
+/** 스캔 결과 캐시. 짧은 TTL(1초)로 동일 호출 체인 내 중복 스캔 방지. */
+const SCAN_CACHE_TTL_MS = 1_000;
+let scanCache: { result: ElectronAppInfo[]; timestamp: number } | null = null;
+
+/** 단일 포트 스캔 */
+async function scanPort(
+  port: number
+): Promise<
+  { port: number; targets: ElectronAppInfo['targets'] } | { port: number; error: string }
+> {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/json`, {
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) {
+      return { port, error: `HTTP ${res.status}` };
+    }
+    const raw = await res.json();
+    const targets = Array.isArray(raw)
+      ? (raw as Array<{
+          id: string;
+          title: string;
+          url: string;
+          type: string;
+          description?: string;
+          webSocketDebuggerUrl?: string;
+        }>)
+      : [];
+    const relevantTargets = targets.filter((t) => t && (t.type === 'page' || t.type === 'node'));
+    if (relevantTargets.length > 0) {
+      return { port, targets: relevantTargets };
+    }
+    return { port, error: `${targets.length} target(s), 0 with type 'page' or 'node'` };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { port, error: msg };
+  }
+}
+
 export async function scanForElectronApps(): Promise<ElectronAppInfo[]> {
-  const found: ElectronAppInfo[] = [];
+  // 캐시 히트: TTL 내 이전 결과 재사용
+  if (scanCache && Date.now() - scanCache.timestamp < SCAN_CACHE_TTL_MS) {
+    return scanCache.result;
+  }
+
   lastScanError = undefined;
-  for (const port of PORTS) {
-    try {
-      const res = await fetch(`http://127.0.0.1:${port}/json`, {
-        signal: AbortSignal.timeout(2000),
-      });
-      if (!res.ok) {
-        lastScanError = `port ${port}: HTTP ${res.status}`;
-        continue;
-      }
-      const raw = await res.json();
-      const targets = Array.isArray(raw)
-        ? (raw as Array<{
-            id: string;
-            title: string;
-            url: string;
-            type: string;
-            description?: string;
-            webSocketDebuggerUrl?: string;
-          }>)
-        : [];
-      const relevantTargets = targets.filter((t) => t && (t.type === 'page' || t.type === 'node'));
-      if (relevantTargets.length > 0) {
-        found.push({ port, targets: relevantTargets });
-        logger.debug(`Found app on port ${port}`, { targets: relevantTargets.length });
-      } else {
-        lastScanError = `port ${port}: ${targets.length} target(s), 0 with type 'page' or 'node'`;
-      }
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      lastScanError = `port ${port}: ${msg}`;
+
+  // 모든 포트를 병렬 스캔
+  const results = await Promise.all(PORTS.map(scanPort));
+
+  const found: ElectronAppInfo[] = [];
+  for (const r of results) {
+    if ('targets' in r) {
+      found.push({ port: r.port, targets: r.targets });
+      logger.debug(`Found app on port ${r.port}`, { targets: r.targets.length });
+    } else {
+      lastScanError = `port ${r.port}: ${r.error}`;
     }
   }
+
+  scanCache = { result: found, timestamp: Date.now() };
   return found;
 }
 


### PR DESCRIPTION
## Summary

- **포트 스캔 병렬화**: `scanForElectronApps`에서 6개 포트를 순차 fetch → `Promise.all` 병렬. 최악 케이스 12초 → 2초
- **스캔 결과 캐싱**: 1초 TTL 캐시 추가. `findElectronTarget` 한 호출 내 3회 중복 스캔 → 1회로 감소
- **CDP enable 병렬화**: console.ts에서 `Console.enable`, `Page.enable`, `Log.enable`, `Runtime.enable` 4개 순차 → `Promise.all` 병렬

## Test plan

- [x] `bun test tests/unit` — 61개 테스트 통과
- [x] `npx tsc --noEmit` — 타입 체크 통과
- [x] `bun run build` — 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)