### PR TITLE
feat(navigation): support DevTools page create and close

### DIFF
--- a/docs/issue-chrome-devtools-mcp-features.md
+++ b/docs/issue-chrome-devtools-mcp-features.md
@@ -16,34 +16,34 @@ electron-mcp-server에서 **Electron 앱(CDP)** 대상으로 동일/유사 기�
 
 ## 내비게이션 (Navigation automation) — 6개
 
-- [ ] `close_page` — `pageId`(페이지 ID)로 탭/페이지 닫기 (CDP 단독 모드: 안내만 반환)
+- [x] `close_page` — `pageId`(페이지 ID)로 탭/페이지 닫기 (DevTools `/json/close/<id>` 엔드포인트 사용)
 - [x] `list_pages` — 열린 페이지 목록 조회 (구현 완료)
 - [x] `navigate_page` — URL 이동 / 뒤로·앞으로 / 새로고침 (구현 완료)
-- [ ] `new_page` — 새 페이지(탭) 열기 (CDP 단독 모드: 안내만 반환)
+- [x] `new_page` — 새 페이지(탭) 열기 (DevTools `/json/new?<url>` 엔드포인트 사용)
 - [x] `select_page` — 이후 도구 호출의 컨텍스트가 될 페이지 선택 (구현 완료)
 - [x] `wait_for` — 지정 텍스트가 나올 때까지 대기 (구현 완료)
 
 ## 에뮬레이션 (Emulation) — 2개
 
-- [ ] `emulate` — 다크/라이트 모드, CPU 스로틀, 지리 위치, 네트워크 조건, User-Agent, 뷰포트 등 에뮬레이션
-- [ ] `resize_page` — 페이지(창) 크기 변경
+- [x] `emulate` — 다크/라이트 모드, CPU 스로틀, 지리 위치, 네트워크 조건, User-Agent, 뷰포트 등 에뮬레이션
+- [x] `resize_page` — 페이지 뷰포트 크기 변경
 
 ## 성능 (Performance) — 3개
 
-- [ ] `performance_analyze_insight` — 트레이스 결과의 특정 인사이트 상세 분석
-- [ ] `performance_start_trace` — 성능 트레이스 녹화 시작 (CWV 등)
-- [ ] `performance_stop_trace` — 성능 트레이스 녹화 중지
+- [x] `performance_analyze_insight` — 트레이스 결과의 특정 인사이트 상세 분석 (TraceEngine 미포함, 안내 반환)
+- [x] `performance_start_trace` — 성능 트레이스 녹화 시작 (CWV 등)
+- [x] `performance_stop_trace` — 성능 트레이스 녹화 중지
 
 ## 네트워크 (Network) — 2개
 
-- [ ] `get_network_request` — 특정 네트워크 요청 상세 조회
-- [ ] `list_network_requests` — 현재 페이지의 네트워크 요청 목록
+- [x] `get_network_request` — 특정 네트워크 요청 상세 조회
+- [x] `list_network_requests` — 현재 페이지와 메인 프로세스 네트워크 요청 목록
 
 ## 디버깅 (Debugging) — 5개
 
 - [x] `evaluate_script` — 페이지 컨텍스트에서 JavaScript 실행 (구현 완료)
-- [ ] `get_console_message` — 콘솔 메시지 ID로 단건 조회
-- [ ] `list_console_messages` — 콘솔 메시지 목록
+- [x] `get_console_message` — 콘솔 메시지 ID로 단건 조회
+- [x] `list_console_messages` — 콘솔 메시지 목록
 - [x] `take_screenshot` — 페이지 뷰포트 스크린샷 (CDP Page.captureScreenshot, outputPath/windowTitle 지원)
 - [x] `take_snapshot` — a11y 트리 기반 페이지 텍스트 스냅샷(uid 부여)
 

--- a/examples/electron-mcp-demo/src/renderer/src/toolList.ts
+++ b/examples/electron-mcp-demo/src/renderer/src/toolList.ts
@@ -29,10 +29,14 @@ export const IMPLEMENTED_IDS = new Set([
   'get_network_request',
   'list_electron_main_ipc_events',
   'get_electron_main_ipc_event',
+  'close_page',
   'list_pages',
   'select_page',
   'navigate_page',
+  'new_page',
   'wait_for',
+  'emulate',
+  'resize_page',
 ]);
 
 /** 테스트 도구는 있으나 MCP 지원에서 제외된 항목 (사이드바에 취소선) */

--- a/packages/electron-mcp-server/src/tools/navigation.ts
+++ b/packages/electron-mcp-server/src/tools/navigation.ts
@@ -1,7 +1,7 @@
 /**
  * 내비게이션 (Navigation automation) — 이슈 #3 로드맵
  * list_pages, select_page, navigate_page, wait_for 실구현.
- * close_page, new_page는 CDP 단독 모드 제한으로 안내만 반환.
+ * new_page, close_page는 DevTools HTTP 엔드포인트로 창/탭 생성을 시도.
  * @see https://github.com/ohah/electron-mcp-server/issues/3
  * @see docs/MCP-SERVER-DESIGN.md (Chrome DevTools MCP 파라미터 스펙)
  */
@@ -13,11 +13,13 @@ import {
   getLastScanError,
   getCurrentApp,
   findElectronTarget,
+  getSelectedPageId,
   setSelectedPageId,
   getTargetByPageId,
   sendCdp,
   withCdpWs,
   executeInElectron,
+  type ElectronAppInfo,
   type DevToolsTarget,
 } from './electron';
 import { CDP_NAVIGATION_TIMEOUT_MS, WAIT_FOR_POLL_MS } from './constants';
@@ -54,6 +56,58 @@ const waitForSchema = z.object({
   text: z.string().min(1, 'text must be non-empty').describe('Text to wait for in the page body'),
   timeout: z.number().optional().default(30_000).describe('Wait timeout (ms)'),
 });
+
+async function requestDevToolsEndpoint(
+  port: number,
+  path: string,
+  method: 'GET' | 'PUT'
+): Promise<Response> {
+  return fetch(`http://127.0.0.1:${port}${path}`, {
+    method,
+    signal: AbortSignal.timeout(5000),
+  });
+}
+
+async function requestDevToolsJson<T>(port: number, path: string): Promise<T> {
+  let res = await requestDevToolsEndpoint(port, path, 'PUT');
+  if (res.status === 404 || res.status === 405) {
+    res = await requestDevToolsEndpoint(port, path, 'GET');
+  }
+  if (!res.ok) {
+    throw new Error(`DevTools endpoint ${path} failed with HTTP ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+async function requestDevToolsText(port: number, path: string): Promise<string> {
+  let res = await requestDevToolsEndpoint(port, path, 'PUT');
+  if (res.status === 404 || res.status === 405) {
+    res = await requestDevToolsEndpoint(port, path, 'GET');
+  }
+  if (!res.ok) {
+    throw new Error(`DevTools endpoint ${path} failed with HTTP ${res.status}`);
+  }
+  return res.text();
+}
+
+async function findAppContainingTarget(pageId: string): Promise<ElectronAppInfo | null> {
+  const apps = await scanForElectronApps();
+  return apps.find((app) => app.targets.some((target) => target.id === pageId)) ?? null;
+}
+
+async function waitForTargetCount(port: number, minCount: number, timeout: number): Promise<void> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const apps = await scanForElectronApps();
+    const app = apps.find((candidate) => candidate.port === port);
+    const pageCount =
+      app?.targets.filter(
+        (target) => target.type === 'page' && !(target.title || '').includes('DevTools')
+      ).length ?? 0;
+    if (pageCount >= minCount) return;
+    await new Promise((resolve) => setTimeout(resolve, WAIT_FOR_POLL_MS));
+  }
+}
 
 async function navigatePageImpl(
   target: DevToolsTarget,
@@ -284,15 +338,35 @@ export function registerNavigationTools(server: McpServer): void {
       inputSchema: closePageSchema,
     },
     async (args: unknown) => {
-      closePageSchema.parse(args);
+      const { pageId } = closePageSchema.parse(args);
+      const app = await findAppContainingTarget(pageId);
+      if (!app) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: false,
+                message: `Page not found: ${pageId}. Use list_pages to see available ids.`,
+              }),
+            },
+          ],
+        };
+      }
+
+      const text = await requestDevToolsText(app.port, `/json/close/${encodeURIComponent(pageId)}`);
+      if (getSelectedPageId() === pageId) {
+        setSelectedPageId(null);
+      }
       return {
         content: [
           {
             type: 'text' as const,
             text: JSON.stringify({
-              ok: false,
-              message:
-                'close_page is not supported when the MCP server connects via CDP only. The Electron app must expose closing a window (e.g. via IPC or send_command_to_electron). Use list_pages to see page ids.',
+              ok: true,
+              pageId,
+              port: app.port,
+              message: text.trim() || `Closed page ${pageId}`,
             }),
           },
         ],
@@ -316,15 +390,51 @@ export function registerNavigationTools(server: McpServer): void {
       inputSchema: newPageSchema,
     },
     async (args: unknown) => {
-      newPageSchema.parse(args);
+      const {
+        url = 'about:blank',
+        background = false,
+        timeout = CDP_NAVIGATION_TIMEOUT_MS,
+      } = newPageSchema.parse(args);
+      const app = await getCurrentApp();
+      if (!app) {
+        const hint = getLastScanError() ? ` (${getLastScanError()})` : '';
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                ok: false,
+                message:
+                  'No Electron app with remote debugging. Start with: electron . --remote-debugging-port=9222' +
+                  hint,
+              }),
+            },
+          ],
+        };
+      }
+
+      const beforeCount = app.targets.filter(
+        (target) => target.type === 'page' && !(target.title || '').includes('DevTools')
+      ).length;
+      const created = await requestDevToolsJson<
+        Partial<DevToolsTarget> & { webSocketDebuggerUrl?: string }
+      >(app.port, `/json/new?${encodeURIComponent(url)}`);
+      if (!background && created.id) {
+        setSelectedPageId(created.id);
+      }
+      await waitForTargetCount(app.port, beforeCount + 1, timeout);
+
       return {
         content: [
           {
             type: 'text' as const,
             text: JSON.stringify({
-              ok: false,
-              message:
-                'new_page is not supported when the MCP server connects via CDP only. Start a new window from the Electron app, then use list_pages and select_page to switch to it.',
+              ok: true,
+              pageId: created.id,
+              title: created.title,
+              url: created.url ?? url,
+              port: app.port,
+              selected: !background,
             }),
           },
         ],

--- a/packages/electron-mcp-server/tests/e2e/mcp-e2e.test.ts
+++ b/packages/electron-mcp-server/tests/e2e/mcp-e2e.test.ts
@@ -82,6 +82,10 @@ describe('MCP E2E', () => {
     expect(names).toContain('select_page');
     expect(names).toContain('navigate_page');
     expect(names).toContain('wait_for');
+    expect(names).toContain('new_page');
+    expect(names).toContain('close_page');
+    expect(names).toContain('emulate');
+    expect(names).toContain('resize_page');
   });
 
   test('tools/call get_electron_window_info', async () => {

--- a/packages/electron-mcp-server/tests/e2e/mcp-with-electron.e2e.test.ts
+++ b/packages/electron-mcp-server/tests/e2e/mcp-with-electron.e2e.test.ts
@@ -180,6 +180,10 @@ describe.skipIf(skipMcpElectronE2E)('MCP + Electron E2E', () => {
     expect(names).toContain('select_page');
     expect(names).toContain('navigate_page');
     expect(names).toContain('wait_for');
+    expect(names).toContain('new_page');
+    expect(names).toContain('close_page');
+    expect(names).toContain('emulate');
+    expect(names).toContain('resize_page');
   });
 
   test('tools/call get_electron_window_info → automationReady', async () => {
@@ -367,6 +371,32 @@ describe.skipIf(skipMcpElectronE2E)('MCP + Electron E2E', () => {
     const content = (res.result as { content?: { type: string; text?: string }[] })?.content ?? [];
     const text = content.find((c) => c.type === 'text')?.text ?? '';
     expect(text).toMatch(/Found text|MCP/);
+  });
+
+  test('tools/call new_page + close_page → 새 페이지 열고 닫기', async () => {
+    const newRes = await callMcp('tools/call', {
+      name: 'new_page',
+      arguments: { url: 'about:blank', timeout: 5000 },
+    });
+    expect(newRes.error).toBeUndefined();
+    const newContent =
+      (newRes.result as { content?: { type: string; text?: string }[] })?.content ?? [];
+    const newText = newContent.find((c) => c.type === 'text')?.text ?? '';
+    const created = JSON.parse(newText) as { ok?: boolean; pageId?: string };
+    expect(created.ok).toBe(true);
+    expect(created.pageId).toBeDefined();
+
+    const closeRes = await callMcp('tools/call', {
+      name: 'close_page',
+      arguments: { pageId: created.pageId },
+    });
+    expect(closeRes.error).toBeUndefined();
+    const closeContent =
+      (closeRes.result as { content?: { type: string; text?: string }[] })?.content ?? [];
+    const closeText = closeContent.find((c) => c.type === 'text')?.text ?? '';
+    const closed = JSON.parse(closeText) as { ok?: boolean; pageId?: string };
+    expect(closed.ok).toBe(true);
+    expect(closed.pageId).toBe(created.pageId);
   });
 
   test('tools/call list_network_requests → 상시 수집 후 목록·상세 조회', async () => {


### PR DESCRIPTION
## Summary
- implement `new_page` with the Electron/Chromium DevTools `/json/new?<url>` endpoint
- implement `close_page` with `/json/close/<pageId>` and clear the selected page when it is closed
- mark navigation/emulation roadmap entries and demo sidebar support state as implemented
- cover tool registration plus the Electron new/close-page flow in E2E tests

Fixes #3.

## Validation
- `bun run typecheck`
- `bun run build:mcp`
- `bun test packages/electron-mcp-server/tests/e2e/mcp-e2e.test.ts`
- `bun run test` (66 pass, 20 skipped because Electron/DISPLAY E2E is skipped without DISPLAY)
- `bun run test:e2e:mcp` (17 skipped because DISPLAY is not set locally)
- `./node_modules/.bin/oxfmt packages/electron-mcp-server/src/tools/navigation.ts packages/electron-mcp-server/tests/e2e/mcp-e2e.test.ts packages/electron-mcp-server/tests/e2e/mcp-with-electron.e2e.test.ts examples/electron-mcp-demo/src/renderer/src/toolList.ts docs/issue-chrome-devtools-mcp-features.md --check`
- `bun run lint` (0 errors; existing unused-variable warnings in tests)