### PR TITLE
test: clean existing lint warnings

### DIFF
--- a/packages/electron-mcp-server/tests/compare-format.mjs
+++ b/packages/electron-mcp-server/tests/compare-format.mjs
@@ -2,7 +2,7 @@ import { WebSocket } from 'ws';
 import http from 'node:http';
 
 function fetchJSON(path) {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     http.get('http://localhost:9222' + path, (res) => {
       let d = '';
       res.on('data', (c) => (d += c));

--- a/packages/electron-mcp-server/tests/unit/deep-resolve-cdp-calls.test.ts
+++ b/packages/electron-mcp-server/tests/unit/deep-resolve-cdp-calls.test.ts
@@ -186,16 +186,7 @@ describe('deepResolveArgs CDP call count', () => {
     const { rootId, registry } = createMockObjectTree(5, 5);
     const counter = { cdpCalls: 0 };
 
-    const result = await formatWithGetProperties(
-      registry,
-      rootId,
-      undefined,
-      0,
-      new Set(),
-      999,
-      50,
-      counter
-    );
+    await formatWithGetProperties(registry, rootId, undefined, 0, new Set(), 999, 50, counter);
 
     // depth 무제한: 리프 노드까지 모두 getProperties 시도
     // total = 1 + 5 + 25 + 125 + 625 + 3125 = 3906
@@ -207,16 +198,7 @@ describe('deepResolveArgs CDP call count', () => {
     const { rootId, registry } = createMockObjectTree(5, 10);
     const counter = { cdpCalls: 0 };
 
-    const result = await formatWithGetProperties(
-      registry,
-      rootId,
-      undefined,
-      0,
-      new Set(),
-      999,
-      50,
-      counter
-    );
+    await formatWithGetProperties(registry, rootId, undefined, 0, new Set(), 999, 50, counter);
 
     // 10 props, 5 depth: 1 + 10 + 100 + 1000 + 10000 + 100000 = 111111
     console.error(`depth=unlimited, 10 props, 5 levels: ${counter.cdpCalls} CDP calls`);
@@ -227,16 +209,7 @@ describe('deepResolveArgs CDP call count', () => {
     const { rootId, registry } = createMockObjectTree(5, 10);
     const counter = { cdpCalls: 0 };
 
-    const result = await formatWithGetProperties(
-      registry,
-      rootId,
-      undefined,
-      0,
-      new Set(),
-      3,
-      50,
-      counter
-    );
+    await formatWithGetProperties(registry, rootId, undefined, 0, new Set(), 3, 50, counter);
 
     // depth 3 제한: 1 + 10 + 100 + 1000 = 1111
     console.error(`depth=3, 10 props, 5 levels: ${counter.cdpCalls} CDP calls`);


### PR DESCRIPTION
## Summary
- remove unused `reject` from the compare-format helper Promise
- stop binding unused `result` values in CDP call-count tests while keeping the awaited calls and assertions intact

Fixes #27.

## Validation
- `bun run lint` (0 warnings, 0 errors)
- `bun test packages/electron-mcp-server/tests/unit/deep-resolve-cdp-calls.test.ts`
- `bun test packages/electron-mcp-server/tests/e2e/mcp-e2e.test.ts`
- `bun run typecheck`
- targeted `oxfmt --check`
- `git diff --check`

Note: `bun run build:mcp` still passes on this `origin/main`-based branch, but it prints the existing MODULE_TYPELESS warning that is addressed separately by PR #26.