### PR TITLE
fix(scripts): run MCP helper from CJS bundle

### DIFF
--- a/packages/electron-mcp-server/scripts/chmod-dist.mjs
+++ b/packages/electron-mcp-server/scripts/chmod-dist.mjs
@@ -1,5 +1,5 @@
 /**
- * dist/index.js에 실행 권한 부여 (Unix). Windows에서는 no-op.
+ * dist/index.cjs에 실행 권한 부여 (Unix). Windows에서는 no-op.
  * 빌드 후 bin 실행 시 Permission denied 방지.
  */
 import fs from 'node:fs';

--- a/packages/electron-mcp-server/scripts/run-mcp.js
+++ b/packages/electron-mcp-server/scripts/run-mcp.js
@@ -1,13 +1,13 @@
 /**
  * MCP 전용 런처: Node 전용 MCP 서버를 실행합니다 (Electron 프로세스 아님).
  * Cursor가 워크스페이스 루트를 cwd로 두고 spawn해도, 패키지 디렉터리를 cwd로 해서
- * node dist/index.js를 실행해 node_modules를 찾을 수 있게 합니다.
+ * node dist/index.cjs를 실행해 node_modules를 찾을 수 있게 합니다.
  */
 const path = require('path');
 const { spawn } = require('child_process');
 
 const pkgDir = path.resolve(path.join(__dirname, '..'));
-const mcpScript = path.join(pkgDir, 'dist', 'index.js');
+const mcpScript = path.join(pkgDir, 'dist', 'index.cjs');
 
 const child = spawn(process.execPath, [mcpScript], {
   cwd: pkgDir,


### PR DESCRIPTION
## Summary
- update `scripts/run-mcp.js` to launch the current `dist/index.cjs` bundle instead of stale `dist/index.js`
- align the chmod helper comment with the current output filename

Fixes #29.

## Validation
- `node --check packages/electron-mcp-server/scripts/run-mcp.js`
- `node --check packages/electron-mcp-server/scripts/chmod-dist.mjs`
- `bun run build:mcp`
- `bun run typecheck`
- `bun test packages/electron-mcp-server/tests/e2e/mcp-e2e.test.ts`
- targeted `oxfmt --check`
- `git diff --check`

Note: `bun run lint` still exits successfully but prints the pre-existing warnings that are addressed separately by PR #28.